### PR TITLE
UX: subgrid layout, image placeholders, other styling

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -21,7 +21,6 @@
 }
 
 .discover-home {
-  overflow-x: hidden;
   .d-header-wrap {
     position: static;
     font-size: var(--font-up-1);
@@ -29,6 +28,7 @@
       background: transparent;
       box-shadow: none;
       .d-header-icons {
+        // hide default discourse nav
         display: none;
       }
     }
@@ -79,7 +79,8 @@
 
   .discover-homepage__directory {
     display: grid;
-    grid-template-areas: "filters directory" "filters footer";
+    grid-template-areas: "filters directory";
+    grid-template-rows: auto 1fr;
     grid-template-columns: 1fr 5fr;
     max-width: var(--d-max-width);
     gap: 1em 4em;
@@ -88,8 +89,21 @@
       gap: 1em 2em;
     }
     @media screen and (max-width: 767px) {
-      grid-template-areas: "filters" "directory" "footer";
+      grid-template-areas: "filters" "directory";
       grid-template-columns: 1fr;
+    }
+  }
+
+  .discover-navigation-list-wrapper {
+    grid-area: filters;
+    align-self: start;
+    padding-left: 0.5em;
+    @media screen and (min-width: 768px) {
+      position: sticky;
+      top: 1em;
+    }
+    @media screen and (max-width: 767px) {
+      padding: 0 1rem;
     }
   }
 
@@ -106,14 +120,11 @@
 
     @media screen and (min-width: 768px) {
       flex-direction: column;
-      padding-left: 0.5em;
-      position: sticky;
-      top: 1em;
     }
 
     @media screen and (max-width: 767px) {
-      padding: 0 1rem;
       font-size: var(--font-0);
+      margin-bottom: 2em;
     }
 
     li {
@@ -137,95 +148,195 @@
           color: currentColor;
         }
       }
+
+      .discourse-no-touch & {
+        &:not(.--active) {
+          &:hover,
+          &:focus {
+            background: var(--primary-100);
+          }
+        }
+      }
+    }
+  }
+
+  .add-your-site {
+    font-size: var(--font-down-2);
+    text-align: center;
+    color: var(--primary-high);
+    h3 {
+      font-weight: normal;
+      margin-top: 2em;
+    }
+
+    @media screen and (max-width: 767px) {
+      display: none;
     }
   }
 
   .discover-list {
-    box-sizing: border-box;
     --border-radius: 1em;
+    grid-area: directory;
+
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(18em, 1fr));
     gap: 2em 1.5em;
+
+    box-sizing: border-box;
     list-style-type: none;
     margin: 0;
-    padding: 0;
     width: 100%;
+
+    padding: 0;
     @media screen and (max-width: 767px) {
       padding: 0 1rem;
-    }
-    @media screen and (max-width: 550px) {
-      grid-template-columns: 1fr;
     }
     @media screen and (min-width: 768px) {
       padding-right: 0.5em;
     }
 
+    > div:not(.loading-container) {
+      display: none; // hides a div created by loadMore component
+    }
+
     &__item {
-      --background-color: var(--secondary);
-      --border-color: var(--primary-200);
-      border-radius: var(--border-radius);
-      background-color: var(--background-color);
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-      transition: all 0.15s ease-in-out;
-      border: 1px solid var(--border-color);
-      .discourse-no-touch & {
-        &:hover,
-        &:focus {
-          --border-color: var(--primary-300);
-          transform: translateY(-1px);
-          box-shadow: var(--shadow-card);
-        }
+      display: grid;
+      grid-template-rows: subgrid; // inherit parent rows
+      grid-row: span 4;
+      gap: 0;
 
-        container-type: inline-size;
+      &:nth-child(5n + 1) {
+        --no-image-background-color: #e84a5120;
+        --no-image-color: #e84a5150;
+      }
+      &:nth-child(5n + 2) {
+        --no-image-background-color: #f0794a20;
+        --no-image-color: #f0794a60;
+      }
+      &:nth-child(5n + 3) {
+        --no-image-background-color: #fbf5af40;
+        --no-image-color: #fbf5af;
+      }
+      &:nth-child(5n + 4) {
+        --no-image-background-color: #0ba64e20;
+        --no-image-color: #0ba64e50;
+      }
+      &:nth-child(5n + 5) {
+        --no-image-background-color: #28abe220;
+        --no-image-color: #28abe250;
       }
 
-      // these container queries
-      // help maintain proportions of each "card"
-      @container (min-width: 20em) {
-        .discover-list__item-banner {
-          height: 13em;
-        }
-      }
+      &-link {
+        display: grid;
+        grid-template-rows: subgrid; // inherit parent rows
+        grid-row: span 4; // set implicit rows on parent
+        grid-template-areas: "banner" "title" "content" "meta";
+        gap: 0;
 
-      @container (min-width: 40em) {
-        .discover-list__item-banner {
-          height: 20em;
+        --content-padding: 0 1.5rem;
+
+        border-radius: var(--border-radius);
+        border: 1px solid var(--primary-200);
+
+        background-color: var(--secondary);
+        overflow: hidden;
+        transition: all 0.15s ease-in-out;
+
+        .discourse-no-touch & {
+          &:hover,
+          &:focus {
+            --border-color: var(--primary-300);
+            transform: translateY(-1px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
+          }
         }
       }
 
       &-banner {
-        width: 100%;
-        background: var(--primary-200);
-        height: 10em;
-        object-fit: cover;
-        object-position: center top;
-        border-bottom: 1px solid var(--primary-200);
-      }
+        grid-area: banner;
+        position: relative;
 
-      &-content {
-        padding: 1.5em;
-        display: flex;
-        flex-direction: column;
+        border-bottom: 1px solid var(--primary-200);
+        margin-bottom: 1em;
+        overflow: hidden;
+
+        container-type: inline-size;
+
+        .no-image {
+          position: absolute;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          font-size: 5em;
+
+          background: var(--no-image-background-color);
+          color: var(--no-image-color);
+        }
+
+        img {
+          width: 100%;
+          height: 9em;
+          object-fit: cover;
+          object-position: center top;
+          &:not([src]) {
+            opacity: 0;
+          }
+
+          // adjust the images somewhat proportionately
+          @container (min-width: 25em) {
+            height: 15em;
+          }
+          @container (min-width: 40em) {
+            height: 25em;
+          }
+        }
       }
 
       h2 {
+        grid-area: title;
         color: var(--primary);
         font-weight: 500;
         display: flex;
-        gap: 0.5em;
+        gap: 0.33em;
         align-items: baseline;
         line-height: var(--line-height-medium);
+        padding: var(--content-padding);
+        margin-bottom: 0.75em;
+        min-width: 0;
+        font-size: var(--font-up-1);
+
+        container-type: inline-size;
+
+        span {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+          overflow: hidden;
+          overflow-wrap: break-word;
+
+          // scale up fonts a little
+          @container (min-width: 20em) {
+            font-size: var(--font-up-2);
+          }
+          @container (min-width: 40em) {
+            font-size: var(--font-up-3);
+          }
+        }
       }
 
-      p {
+      &-excerpt {
+        grid-area: content;
         color: var(--primary-high);
-        margin: 0.75em 0 0;
+        margin: 0;
         display: -webkit-box;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: 4;
+        -webkit-line-clamp: 3;
         overflow: hidden;
+        padding: var(--content-padding);
       }
 
       &-logo {
@@ -238,10 +349,22 @@
       }
 
       &-meta {
+        grid-area: meta;
         color: var(--primary-medium);
         font-size: var(--font-down-1);
         display: flex;
         gap: 1em;
+        padding: var(--content-padding);
+        margin: 1.5em 0 1em;
+
+        .d-icon {
+          color: var(--primary-high);
+        }
+
+        .d-icon-user-friends {
+          top: 0.05em; // optical alignment
+        }
+
         span {
           display: flex;
           align-items: center;
@@ -259,23 +382,6 @@
       font-size: var(--font-up-2);
       height: 10vh;
     }
-  }
-
-  .add-your-site {
-    margin: 1em 0;
-    @media screen and (max-width: 767px) {
-      margin: 1rem;
-    }
-    h3 {
-      font-weight: normal;
-      font-family: var(--font-family);
-    }
-  }
-}
-
-.--no-results {
-  .add-your-site {
-    display: none;
   }
 }
 
@@ -456,7 +562,7 @@
 
 #lasso-returns {
   height: 1.67em;
-  right: -0.67em;
+  right: 0.67em;
   top: 4.67em;
 
   @media screen and (prefers-reduced-motion: no-preference) {

--- a/javascripts/discourse/components/custom-homepage.gjs
+++ b/javascripts/discourse/components/custom-homepage.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
-import i18n from "discourse-common/helpers/i18n";
 import Blobs from "../components/blobs";
 import HomeList from "../components/home-list";
 import NavigationList from "../components/navigation-list";
@@ -17,18 +16,6 @@ export default class CustomHomepage extends Component {
       <div class="discover-homepage__directory">
         <NavigationList />
         <HomeList />
-        {{#unless this.homepageFilter.loading}}
-          <div class="add-your-site">
-            <h3>
-              {{i18n (themePrefix "footer.add_message")}}
-              <a
-                href="https://meta.discourse.org/t/introducing-discourse-discover/295223"
-              >
-                {{i18n (themePrefix "footer.add_link")}}
-              </a>
-            </h3>
-          </div>
-        {{/unless}}
       </div>
     </div>
 

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import LoadMore from "discourse/components/load-more";
 import bodyClass from "discourse/helpers/body-class";
@@ -38,6 +39,7 @@ export default class HomeList extends Component {
     <ul class="discover-list" {{didInsert this.homepageFilter.getSiteList}}>
       {{#if this.homepageFilter.topicResults}}
         {{#each this.homepageFilter.topicResults as |topic|}}
+          {{log topic}}
           <li class="discover-list__item">
             <a
               href={{topic.featured_link}}
@@ -45,33 +47,38 @@ export default class HomeList extends Component {
               rel="noopener noreferrer"
               class="discover-list__item-link"
             >
-              <img
-                class="discover-list__item-banner"
-                srcset={{topic.bannerImage.srcset}}
-                src={{topic.bannerImage.src}}
-                sizes={{topic.bannerImage.sizes}}
-              />
-              <div class="discover-list__item-content">
-                <h2>
+              <div class="discover-list__item-banner">
+                <img
+                  srcset={{topic.bannerImage.srcset}}
+                  src={{topic.bannerImage.src}}
+                  sizes={{topic.bannerImage.sizes}}
+                />
+                {{#unless topic.bannerImage.src}}
+                  <div class="no-image">{{dIcon "fab-discourse"}}</div>
+                {{/unless}}
+              </div>
+              <h2>
+                {{#if topic.image_url}}
+                  {{! todo — replace image with logo}}
                   <img
                     class="discover-list__item-logo"
                     src={{topic.image_url}}
                   />
-                  {{topic.title}}
-                </h2>
-                <div class="discover-list__item-meta">
-                  {{#if topic.topics_30_days}}
-                    <span>{{dIcon "comments"}}{{topic.topics_30_days}}</span>
-                  {{/if}}
-                  {{#if topic.users_30_days}}
-                    <span>{{dIcon "user"}}
-                      {{topic.users_30_days}}</span>
-                  {{/if}}
-                </div>
-                <p class="discover-list__item-excerpt">
-                  {{topic.excerpt}}
-                </p>
+                {{/if}}
+                <span>{{topic.title}}</span>
+              </h2>
+              <div class="discover-list__item-meta">
+                {{#if topic.users_30_days}}
+                  <span>{{dIcon "user-friends"}}
+                    {{topic.users_30_days}}</span>
+                {{/if}}
+                {{#if topic.topics_30_days}}
+                  <span>{{dIcon "comments"}}{{topic.topics_30_days}}</span>
+                {{/if}}
               </div>
+              <p class="discover-list__item-excerpt">
+                {{htmlSafe topic.excerpt}}
+              </p>
             </a>
           </li>
         {{/each}}

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -39,7 +39,6 @@ export default class HomeList extends Component {
     <ul class="discover-list" {{didInsert this.homepageFilter.getSiteList}}>
       {{#if this.homepageFilter.topicResults}}
         {{#each this.homepageFilter.topicResults as |topic|}}
-          {{log topic}}
           <li class="discover-list__item">
             <a
               href={{topic.featured_link}}

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -38,19 +38,33 @@ export default class NavigationList extends Component {
 
   <template>
     {{! template-lint-disable no-invalid-interactive }}
-    <ul class="discover-navigation-list">
-      {{#each this.navItems as |item|}}
-        <li
-          data-tag-name={{item.tagName}}
-          {{on "click" (fn this.updateFilter item.tagName)}}
-          class="discover-navigation-list__item {{if item.isActive '--active'}}"
-        >
-          {{#if item.icon}}
-            {{dIcon item.icon}}
-          {{/if}}
-          {{item.label}}
-        </li>
-      {{/each}}
-    </ul>
+    <div class="discover-navigation-list-wrapper">
+      <ul class="discover-navigation-list">
+        {{#each this.navItems as |item|}}
+          <li
+            data-tag-name={{item.tagName}}
+            {{on "click" (fn this.updateFilter item.tagName)}}
+            class="discover-navigation-list__item
+              {{if item.isActive '--active'}}"
+          >
+            {{#if item.icon}}
+              {{dIcon item.icon}}
+            {{/if}}
+            {{item.label}}
+          </li>
+        {{/each}}
+      </ul>
+
+      <div class="add-your-site">
+        <h3>
+          {{i18n (themePrefix "footer.add_message")}}
+          <a
+            href="https://meta.discourse.org/t/introducing-discourse-discover/295223"
+          >
+            {{i18n (themePrefix "footer.add_link")}}
+          </a>
+        </h3>
+      </div>
+    </div>
   </template>
 }

--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -44,8 +44,8 @@ export default class HomepageFilter extends Service {
 
   createBannerImage(thumbnails) {
     const srcset = this.createSrcset(thumbnails);
-    const sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw";
-    const src = thumbnails[0].url;
+    const sizes = "(max-width: 500px) 400px, (max-width: 600px) 800px, 1024px";
+    const src = thumbnails[0].url; // default
 
     return { srcset, sizes, src };
   }


### PR DESCRIPTION
Adds some placeholder images 

![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/83893f3a-9a11-497a-8fff-e0a9ac0b0124)

Makes the grid layout more responsive and moves the footer message to below the filters:

![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/042ffbde-e20c-4bc7-a600-d71f5e648fa9)

![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/a7db7abd-5150-4504-bb4b-89ff1de1b06e)


![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/d7dbe024-8bcf-49cb-b549-949c47728eb8)
