### PR TITLE
Show instance logos in list

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -254,6 +254,12 @@
             --border-color: var(--primary-300);
             transform: translateY(-1px);
             box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
+
+            .discover-list__item-banner > img {
+              opacity: 1;
+              transform: scale(1.1);
+              transition: all 0.25s ease-in-out;
+            }
           }
         }
       }
@@ -263,7 +269,7 @@
         position: relative;
 
         border-bottom: 1px solid var(--primary-200);
-        margin-bottom: 1em;
+        margin-bottom: 1.5em;
         overflow: hidden;
 
         container-type: inline-size;
@@ -288,6 +294,7 @@
           height: 9em;
           object-fit: cover;
           object-position: center top;
+          opacity: 0.75;
           &:not([src]) {
             opacity: 0;
           }
@@ -346,12 +353,21 @@
       }
 
       &-logo {
-        width: 1em;
-        height: 1em;
-        border-radius: 0.25em;
-        position: relative;
-        top: 0.12em; // optical alignment
+        width: 4em;
+        height: 4em;
+        margin-left: -2em;
+        position: absolute;
+        top: 6em;
+        left: 50%;
         flex: 0 0 auto;
+        border-radius: 2em;
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+        img {
+          border-radius: 2em;
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
       }
 
       &-meta {

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -68,14 +68,12 @@ export default class HomeList extends Component {
                   <div class="no-image">{{dIcon "fab-discourse"}}</div>
                 {{/unless}}
               </div>
+              {{#if topic.discover_entry_logo_url}}
+                <div class="discover-list__item-logo">
+                  <img src={{topic.discover_entry_logo_url}}/>
+                </div>
+              {{/if}}
               <h2>
-                {{#if topic.image_url}}
-                  {{! todo — replace image with logo}}
-                  <img
-                    class="discover-list__item-logo"
-                    src={{topic.image_url}}
-                  />
-                {{/if}}
                 <span>{{topic.title}}</span>
               </h2>
               <div class="discover-list__item-meta">


### PR DESCRIPTION
@awesomerobot I tried a different way to show the instance logos, curious what you think. My motivations are the following: 

- show logos a bit more prominently
- keep text alignment between title and excerpt
- downplay the screenshots a tiny bit

Not sure it works for all cases, please go with what you think is best. 

<img width="922" alt="image" src="https://github.com/discourse/discourse-discover-theme/assets/368961/24865c73-6353-4ca7-84fd-a658cb041f51">
