### PR TITLE
FIX: don't redirect from login routes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -6,9 +6,16 @@
     "Noto Color Emoji";
 }
 
-html.anon body:not(.discover-home) {
-  // hide other page content from anon users
-  display: none;
+html.anon {
+  body:not(.discover-home):not(.static-login) {
+    // hide other page content from anon users
+    display: none;
+  }
+  body[class=""] {
+    // the admin login route has no class
+    // so it's a special case
+    display: block !important;
+  }
 }
 
 @font-face {

--- a/javascripts/discourse/initializers/init-force-home.gjs
+++ b/javascripts/discourse/initializers/init-force-home.gjs
@@ -8,7 +8,14 @@ export default apiInitializer("1.15.0", (api) => {
     const router = api.container.lookup("service:router");
     const currentUser = api.container.lookup("service:currentUser");
     const currentRouteName = router?.currentRouteName;
-    if (!currentUser && currentRouteName !== `discovery.${defaultHomepage()}`) {
+
+    const excludeRoutes = [
+      "login",
+      "email-login",
+      `discovery.${defaultHomepage()}`,
+    ];
+
+    if (!currentUser && !excludeRoutes.includes(currentRouteName)) {
       router.transitionTo("/");
     }
   });


### PR DESCRIPTION
Follow up to 68a9521, we still don't want anons browsing various unstyled routes — but this was too broad and preventing admin logins