### PR TITLE
UX: minor mobile style improvements, hide login

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -39,6 +39,7 @@ html.anon {
     .d-header {
       background: transparent;
       box-shadow: none;
+      .header-buttons,
       .d-header-icons {
         // hide default discourse nav
         display: none;
@@ -81,6 +82,9 @@ html.anon {
       font-size: 2.75em;
       margin-bottom: 0.5em;
       line-height: 1.2;
+      @include breakpoint("mobile-extra-large") {
+        font-size: 2em;
+      }
     }
 
     input {
@@ -139,7 +143,7 @@ html.anon {
     }
 
     @media screen and (max-width: 767px) {
-      font-size: var(--font-0);
+      font-size: var(--font-down-1);
       margin-bottom: 2em;
     }
 
@@ -369,6 +373,7 @@ html.anon {
 
       &-logo {
         width: 10%;
+        max-width: 2em; // don't have the resolution for larger
         grid-area: banner;
         z-index: 2;
         background: var(--secondary);

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,5 +12,5 @@ en:
     add_link: Learn More
   tooltip:
     users: logged in visitors over the past 30 days
-    posts: posts over the past 30 days
+    posts: topics over the past 30 days
   to_top: "Back to top"


### PR DESCRIPTION
* Hide login button
* Shrink heading and filters on mobile
* Update "posts" to "topics" in tooltip for accuracy
* Limits logo width on cards 

Before:
![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/7a3479ec-d70d-4dcd-98e1-155aada7371a)

After:
![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/8573b8f1-949a-4cdc-a247-9736b302b10d)
