### PR TITLE
FIX: prevent flicker on email-login route

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -7,7 +7,7 @@
 }
 
 html.anon {
-  body:not(.discover-home):not(.static-login) {
+  body:not(.discover-home):not(.static-login):not(.has-sidebar-page) {
     // hide other page content from anon users
     display: none;
   }


### PR DESCRIPTION
Fixes this slightly strange issue... there's some kind of fight with the has-sidebar-page class: 


https://github.com/discourse/discourse-discover-theme/assets/1681963/453bb689-6811-41f5-9ec5-ea6dd000e60d

