### PR TITLE
FIX: hide auth buttons, show nav

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -39,7 +39,7 @@ html.anon {
     .d-header {
       background: transparent;
       box-shadow: none;
-      .header-buttons,
+      .auth-buttons,
       .d-header-icons {
         // hide default discourse nav
         display: none;


### PR DESCRIPTION
Overlooked this when hiding auth buttons

Before:
![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/638d6981-79c3-45d4-a821-3b700fe5d299)


After:
![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/3b047f67-2cda-43cc-ba2f-5c8f7bdc40bd)
