### PR TITLE
UX: comma separation for topic and user counts

### DIFF
--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -33,13 +33,17 @@ export default class HomeList extends Component {
   };
 
   roundStat(num) {
+    let rounded;
+
     if (num < 10) {
-      return num;
+      rounded = num;
     } else if (num < 1000) {
-      return Math.ceil(num / 10) * 10;
+      rounded = Math.ceil(num / 10) * 10;
     } else {
-      return Math.ceil(num / 100) * 100;
+      rounded = Math.ceil(num / 100) * 100;
     }
+
+    return rounded.toLocaleString();
   }
 
   get multiPageEnd() {
@@ -112,7 +116,6 @@ export default class HomeList extends Component {
   }
 
   <template>
-    {{! template-lint-disable no-invalid-interactive }}
     {{bodyClass "discover-home"}}
 
     <ul class="discover-list" {{didInsert this.homepageFilter.getSiteList}}>


### PR DESCRIPTION
Before:

![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/daba0193-20b7-46b1-83a9-17e5d1084084)


After:


![image](https://github.com/discourse/discourse-discover-theme/assets/1681963/6188ee1f-91fe-4fd1-b6a7-05992639b624)


Also removed a lint-disable that's no longer necessary