### PR TITLE
UX: Switch to showing active users

### DIFF
--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -149,12 +149,12 @@ export default class HomeList extends Component {
                 <span>{{topic.title}}</span>
               </h2>
               <div class="discover-list__item-meta">
-                {{#if topic.users_30_days}}
+                {{#if topic.active_users_30_days}}
                   <span>
                     <DTooltip @identifier="active-topics">
                       <:trigger>
                         {{dIcon "user-friends"}}
-                        {{this.roundStat topic.users_30_days}}
+                        {{this.roundStat topic.active_users_30_days}}
                       </:trigger>
                       <:content>
                         {{i18n (themePrefix "tooltip.users")}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,6 +11,6 @@ en:
     add_message: Want to add your community?
     add_link: Learn More
   tooltip:
-    users: logged in visitors over the past 30 days
+    users: users active in the past 30 days
     posts: topics over the past 30 days
   to_top: "Back to top"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,6 +11,6 @@ en:
     add_message: Want to add your community?
     add_link: Learn More
   tooltip:
-    users: users active in the past 30 days
+    users: signed-in users active in the past 30 days
     posts: topics over the past 30 days
   to_top: "Back to top"


### PR DESCRIPTION
`users_30_days` is in fact "user signups over the past 30 days". Using `active_users_30_days` instead is better, it shows the active number of users on the site, which is a more useful metric.