### PR TITLE
UX: hide logos that fail to load, restrict aspect ratio, avoid errors

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -301,7 +301,6 @@ html.anon {
           &:focus {
             --border-color: var(--primary-300);
             box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
-            transform: translate3d(0, -0.15em, 0);
           }
         }
       }
@@ -410,8 +409,11 @@ html.anon {
         display: flex;
         align-items: center;
         justify-content: center;
+        aspect-ratio: 1 / 1;
 
         img {
+          min-height: 1.625em;
+          min-width: 1.625em;
           border-radius: 5px;
           width: 95%;
           height: 95%;

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -63,6 +63,10 @@ export default class HomeList extends Component {
   checkImageBackgroundColor(event) {
     const imageElement = event.target;
 
+    if (imageElement.naturalWidth === 0 || imageElement.naturalHeight === 0) {
+      return;
+    }
+
     const canvas = document.createElement("canvas");
     canvas.width = imageElement.naturalWidth;
     canvas.height = imageElement.naturalHeight;
@@ -115,6 +119,15 @@ export default class HomeList extends Component {
     );
   }
 
+  @action
+  hideImageOnError(event) {
+    const imageElement = event.target;
+    const parentContainer = imageElement.closest(".discover-list__item-logo");
+    if (parentContainer) {
+      parentContainer.style.display = "none";
+    }
+  }
+
   <template>
     {{bodyClass "discover-home"}}
 
@@ -142,9 +155,10 @@ export default class HomeList extends Component {
                 <div class="discover-list__item-logo">
                   <img
                     src={{topic.discover_entry_logo_url}}
-                    alt="topic logo"
+                    alt=""
                     crossOrigin="Anonymous"
                     {{on "load" this.checkImageBackgroundColor}}
+                    {{on "error" this.hideImageOnError}}
                   />
                 </div>
               {{/if}}


### PR DESCRIPTION
* Hides logos that fail to load due to blocked CORS requests
* Restricts logos to a square aspect ratio
* Sets minimum logo dimensions
* Fixes error when attempting to check background of 0-dimension images
* Blank alt attribute from logo, these are decorative so screen readers can ignore them