### PR TITLE
UX: add locale filter

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -118,6 +118,7 @@ html.anon {
     grid-area: filters;
     align-self: start;
     padding-left: 0.5em;
+    z-index: 9;
     @media screen and (min-width: 768px) {
       position: sticky;
       top: 1em;
@@ -506,6 +507,12 @@ html.anon {
       color: var(--primary-medium);
       margin-right: .25em;
       font-size: var(--font-down-2);
+    }
+  }
+
+  &__list-item {
+    .select-kit.is-expanded .select-kit-body {
+      width: 180px;
     }
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -499,13 +499,13 @@ html.anon {
 .locale-switcher {
   width: 100%;
   &.select-kit.combo-box .select-kit-header {
-    border-radius: .25em;
-    padding-block: .33em;
+    border-radius: 0.25em;
+    padding-block: 0.33em;
   }
   .select-kit-header-wrapper {
     .svg-icon:not(.caret-icon) {
       color: var(--primary-medium);
-      margin-right: .25em;
+      margin-right: 0.25em;
       font-size: var(--font-down-2);
     }
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -500,7 +500,7 @@ html.anon {
   width: 100%;
   &.select-kit.combo-box .select-kit-header {
     border-radius: .25em;
-    padding-block: .25em;
+    padding-block: .33em;
   }
   .select-kit-header-wrapper {
     .svg-icon:not(.caret-icon) {

--- a/common/common.scss
+++ b/common/common.scss
@@ -517,6 +517,12 @@ html.anon {
   }
 }
 
+.discover-home:not(.locale-en) {
+  .discover-navigation-list__filter-wrapper {
+    display: none;
+  }
+}
+
 .learn-more-modal {
   .d-modal__container {
     --modal-max-width: 550px;

--- a/common/common.scss
+++ b/common/common.scss
@@ -495,6 +495,21 @@ html.anon {
   }
 }
 
+.locale-switcher {
+  width: 100%;
+  &.select-kit.combo-box .select-kit-header {
+    border-radius: .25em;
+    padding-block: .25em;
+  }
+  .select-kit-header-wrapper {
+    .svg-icon:not(.caret-icon) {
+      color: var(--primary-medium);
+      margin-right: .25em;
+      font-size: var(--font-down-2);
+    }
+  }
+}
+
 .learn-more-modal {
   .d-modal__container {
     --modal-max-width: 550px;

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -5,6 +5,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
+import bodyClass from "discourse/helpers/body-class";
 import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import { bind } from "discourse-common/utils/decorators";
@@ -25,8 +26,10 @@ export default class NavigationList extends Component {
 
   @action
   updateLocale(locale) {
+    // when switching locale, we want to reset everything else
     this.homepageFilter.locale = locale;
-    localStorage.setItem("DiscoverLocale", locale);
+    this.homepageFilter.tagFilter = null;
+    this.homepageFilter.resetSearch();
     this.homepageFilter.resetPageAndFetch();
   }
 
@@ -57,10 +60,21 @@ export default class NavigationList extends Component {
   }
 
   <template>
+    {{bodyClass this.homepageFilter.locale}}
     <div class="discover-navigation-list-wrapper">
       <ul class="discover-navigation-list">
+        <li class="locale-switcher__list-item">
+          <ComboBox
+            class="locale-switcher discover-navigation-list__item"
+            @valueProperty="tagName"
+            @content={{this.localeList}}
+            @value={{this.homepageFilter.locale}}
+            @onChange={{this.updateLocale}}
+            @options={{hash icon="globe"}}
+          />
+        </li>
         {{#each this.navItems as |item|}}
-          <li>
+          <li class="discover-navigation-list__filter-wrapper">
             <button
               type="button"
               data-tag-name={{item.tagName}}
@@ -78,16 +92,6 @@ export default class NavigationList extends Component {
             </button>
           </li>
         {{/each}}
-        <li class="locale-switcher__list-item">
-          <ComboBox
-            class="locale-switcher discover-navigation-list__item"
-            @valueProperty="tagName"
-            @content={{this.localeList}}
-            @value={{this.homepageFilter.locale}}
-            @onChange={{this.updateLocale}}
-            @options={{hash icon="globe"}}
-          />
-        </li>
         <li class="add-your-site">
           <FaqButton />
         </li>

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -8,6 +8,9 @@ import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import { bind } from "discourse-common/utils/decorators";
 import FaqButton from "../components/faq-button";
+import ComboBox from "select-kit/components/combo-box";
+import { action } from "@ember/object";
+import { hash } from "@ember/helper";
 
 export default class NavigationList extends Component {
   @service store;
@@ -19,6 +22,13 @@ export default class NavigationList extends Component {
   @bind
   updateFilter(tagName) {
     this.homepageFilter.updateFilter(tagName);
+  }
+
+  @action
+  updateLocale(locale) {
+    this.homepageFilter.locale = locale;
+    localStorage.setItem("DiscoverLocale", locale);
+    this.homepageFilter.resetPageAndFetch();
   }
 
   get navItems() {
@@ -36,6 +46,15 @@ export default class NavigationList extends Component {
     }));
 
     return [allItem, ...tagItems];
+  }
+
+  get localeList() {
+    const locales = settings.locale_filter.map(locale => ({
+      tagName: locale.tag[0],
+      label: locale.text,
+    }));
+
+    return locales;
   }
 
   <template>
@@ -60,6 +79,16 @@ export default class NavigationList extends Component {
             </button>
           </li>
         {{/each}}
+        <li class="locale-switcher__list-item">
+          <ComboBox
+            class="locale-switcher discover-navigation-list__item"
+            @valueProperty="tagName"
+            @content={{this.localeList}}
+            @value={{this.homepageFilter.locale}}
+            @onChange={{this.updateLocale}}
+            @options={{hash icon="globe"}}
+          />
+        </li>
         <li class="add-your-site">
           <FaqButton />
         </li>

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -70,7 +70,7 @@ export default class NavigationList extends Component {
             @content={{this.localeList}}
             @value={{this.homepageFilter.locale}}
             @onChange={{this.updateLocale}}
-            @options={{hash icon="globe"}}
+            @options={{hash icon="globe" autoFilterable=false}}
           />
         </li>
         {{#each this.navItems as |item|}}

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -1,16 +1,15 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn } from "@ember/helper";
+import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import { bind } from "discourse-common/utils/decorators";
-import FaqButton from "../components/faq-button";
 import ComboBox from "select-kit/components/combo-box";
-import { action } from "@ember/object";
-import { hash } from "@ember/helper";
+import FaqButton from "../components/faq-button";
 
 export default class NavigationList extends Component {
   @service store;

--- a/javascripts/discourse/components/navigation-list.gjs
+++ b/javascripts/discourse/components/navigation-list.gjs
@@ -49,7 +49,7 @@ export default class NavigationList extends Component {
   }
 
   get localeList() {
-    const locales = settings.locale_filter.map(locale => ({
+    const locales = settings.locale_filter.map((locale) => ({
       tagName: locale.tag[0],
       label: locale.text,
     }));

--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -14,6 +14,7 @@ export default class HomepageFilter extends Service {
   @tracked loading = false;
   @tracked hasMoreResults = false;
   @tracked currentPage = 1;
+  @tracked locale = localStorage.getItem("DiscoverLocale") || "locale-en";
 
   updateFilter(filter) {
     this.resetSearch();
@@ -77,10 +78,9 @@ export default class HomepageFilter extends Service {
     if (this.searchQuery) {
       searchString += ` ${this.searchQuery}`;
     }
-    if (!this.searchQuery && !this.tagFilter) {
-      // show English-only entries in default list
-      searchString += ` #locale-en`;
-    }
+
+    searchString += ` #${this.locale}`;
+    
     if (!this.searchQuery || !this.searchQuery.includes("order:")) {
       // use "order:featured" from the discourse-discover plugin as default sort
       // allows overriding order in search input

--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -72,14 +72,20 @@ export default class HomepageFilter extends Service {
     );
 
     let searchString = `#${category?.slug}`;
-    if (this.tagFilter) {
-      searchString += ` tags:${this.tagFilter}`;
+
+    searchString += ` #${this.locale}`;
+
+    if (this.locale === "locale-en") {
+      // only use the additional tag filters for the English locale
+      // because there aren't enough sites to populate the others yet
+      if (this.tagFilter) {
+        searchString += ` tags:${this.tagFilter}`;
+      }
     }
+
     if (this.searchQuery) {
       searchString += ` ${this.searchQuery}`;
     }
-
-    searchString += ` #${this.locale}`;
 
     if (!this.searchQuery || !this.searchQuery.includes("order:")) {
       // use "order:featured" from the discourse-discover plugin as default sort

--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -80,7 +80,7 @@ export default class HomepageFilter extends Service {
     }
 
     searchString += ` #${this.locale}`;
-    
+
     if (!this.searchQuery || !this.searchQuery.includes("order:")) {
       // use "order:featured" from the discourse-discover plugin as default sort
       // allows overriding order in search input

--- a/settings.yml
+++ b/settings.yml
@@ -14,7 +14,7 @@ homepage_filter:
       button_text:
         type: string
 
-locale_filter: 
+locale_filter:
   type: objects
   default: []
   schema:

--- a/settings.yml
+++ b/settings.yml
@@ -14,5 +14,20 @@ homepage_filter:
       button_text:
         type: string
 
+locale_filter: 
+  type: objects
+  default: []
+  schema:
+    name: "locale"
+    identifier: text
+    properties:
+      tag:
+        type: tags
+        required: true
+        validations:
+          min_length: 1
+      text:
+        type: string
+
 svg_icons:
   default: "user-astronaut"


### PR DESCRIPTION
This adds a locale filter, populated by tags added to the `locale_filter` setting.

Since there's a low volume of sites in locales other than English, I hide the sidebar filters and reset search when switching. 

![image](https://github.com/user-attachments/assets/2f902595-5549-4bc5-9eee-f86ec8822eec)


![image](https://github.com/user-attachments/assets/5a8196b4-ddd3-4063-b9bf-6a92f9c4c32c)




This will allow us to remove the generic "international" category 