### PR TITLE
FIX: remove locale when using text search

### DIFF
--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -3,6 +3,10 @@ import { action } from "@ember/object";
 import Service, { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import Category from "discourse/models/category";
+import i18n from "discourse-common/helpers/i18n";
+
+const ALL_LOCALE = i18n(themePrefix("navigation.all"));
+const DEFAULT_LOCALE = "locale-en";
 
 export default class HomepageFilter extends Service {
   @service siteSettings;
@@ -14,7 +18,7 @@ export default class HomepageFilter extends Service {
   @tracked loading = false;
   @tracked hasMoreResults = false;
   @tracked currentPage = 1;
-  @tracked locale = localStorage.getItem("DiscoverLocale") || "locale-en";
+  @tracked locale = DEFAULT_LOCALE;
 
   updateFilter(filter) {
     this.resetSearch();
@@ -27,7 +31,13 @@ export default class HomepageFilter extends Service {
     if (this.searchQuery !== query) {
       this.searchQuery = query;
       this.tagFilter = null;
+      this.locale = ALL_LOCALE;
       this.resetPageAndFetch();
+    }
+
+    if (this.searchQuery === "") {
+      // reset locale to default when clearing search
+      this.locale = DEFAULT_LOCALE;
     }
   }
 
@@ -73,9 +83,11 @@ export default class HomepageFilter extends Service {
 
     let searchString = `#${category?.slug}`;
 
-    searchString += ` #${this.locale}`;
+    if (this.locale !== ALL_LOCALE) {
+      searchString += ` #${this.locale}`;
+    }
 
-    if (this.locale === "locale-en") {
+    if (this.locale === DEFAULT_LOCALE) {
       // only use the additional tag filters for the English locale
       // because there aren't enough sites to populate the others yet
       if (this.tagFilter) {


### PR DESCRIPTION
In the current state, you can't search for all sites... it's limited to your currently selected locale: 

![image](https://github.com/user-attachments/assets/deb65037-5298-4cd3-a990-b9ef4b619c0c)

☝🏻 This defies user expectations a little bit.

👇🏻 I've updated this so if you use text search, we'll search all locales to give you the best possible odds:  

![image](https://github.com/user-attachments/assets/c21e6852-c434-4923-9813-ab68e3269f4d)

At this point, the locale is switched to a fake "all" value so the functionality is a little more apparent. If someone selects a different locale from the dropdown, the text search is removed and you're shown all sites in that locale again. 

If you remove your text from search, you're sent back to the default state (English locale)