### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -435,7 +435,7 @@ html.anon {
           color: var(--primary-high);
         }
 
-        .d-icon-user-friends {
+        .d-icon-user-group {
           top: 0.05em; // optical alignment
         }
 

--- a/javascripts/discourse/components/faq-button.gjs
+++ b/javascripts/discourse/components/faq-button.gjs
@@ -33,7 +33,7 @@ export default class NavigationList extends Component {
       @action={{this.showLearnMoreModal}}
       @translatedLabel={{i18n (themePrefix "footer.learn_more")}}
       class="btn-transparent"
-      @icon="question-circle"
+      @icon="circle-question"
     />
   </template>
 }


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.