### PR TITLE
UX: show a message to filter when max results are met

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -188,6 +188,7 @@ html.anon {
         button {
           padding: 0;
           color: var(--tertiary);
+          background: transparent;
           .d-icon {
             display: none;
           }
@@ -493,6 +494,12 @@ html.anon {
         text-decoration: underline;
       }
     }
+  }
+
+  .max-results {
+    margin-bottom: 3em;
+    max-width: 70%;
+    text-align: center;
   }
 }
 

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -218,6 +218,11 @@ export default class HomeList extends Component {
         {{#unless this.homepageFilter.loading}}
           {{#if this.multiPageEnd}}
             <li class="discover-list__item --end">
+              {{#if this.homepageFilter.maxResults}}
+                <div class="max-results">
+                  {{i18n (themePrefix "too_many_results")}}
+                </div>
+              {{/if}}
               <Rocket @rocketLaunch={{this.rocketLaunch}} />
               <DButton
                 @action={{this.scrollTop}}

--- a/javascripts/discourse/services/homepage-filter.js
+++ b/javascripts/discourse/services/homepage-filter.js
@@ -17,6 +17,7 @@ export default class HomepageFilter extends Service {
   @tracked inputText = "";
   @tracked loading = false;
   @tracked hasMoreResults = false;
+  @tracked maxResults = false;
   @tracked locale = DEFAULT_LOCALE;
   @tracked currentPage = 1;
   // search endpoint in core is currently limited to 10 pages of results
@@ -52,6 +53,7 @@ export default class HomepageFilter extends Service {
     this.currentPage = 1;
     this.topicResults = [];
     this.hasMoreResults = false;
+    this.maxResults = false;
     this.getSiteList();
   }
 
@@ -126,6 +128,7 @@ export default class HomepageFilter extends Service {
 
     if (this.currentPage > this.maxPage) {
       this.hasMoreResults = false;
+      this.maxResults = true;
       return;
     }
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -13,6 +13,7 @@ en:
     users: signed-in users active in the past 30 days
     posts: topics over the past 30 days
   to_top: "Back to top"
+  too_many_results: "There are more results than we can show here! Try filtering to find them."
   faq_modal:
     intro: "Discourse Discover is a directory of communities built using the open-source <a href='https://www.discourse.org'>Discourse</a> discussion platform. You can start your own community using our <a href='https://www.discourse.org/pricing'>official hosting</a>, or <a href='https://github.com/discourse/discourse/blob/main/docs/INSTALL-cloud.md'>install it yourself</a>!"
     title: "Discover FAQs"


### PR DESCRIPTION
We can only show 10 pages of results using the /search endpoint, so this adds a message to suggest filtering to find more

![image](https://github.com/user-attachments/assets/a696ff9a-81b5-45c0-afb4-0f8f84184ba5)
