### PR TITLE
FEATURE: add ability to display promo card

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -550,3 +550,4 @@ html.anon {
 
 @import "blobs";
 @import "rocket";
+@import "promo";

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -17,8 +17,6 @@ import Rocket from "../components/rocket";
 export default class HomeList extends Component {
   @service site;
   @service capabilities;
-  @service store;
-  @service siteSettings;
   @service homepageFilter;
   @service currentUser;
 
@@ -54,6 +52,7 @@ export default class HomeList extends Component {
     );
   }
 
+  @cached
   get promoConfig() {
     return settings.promo_tile[0] || {};
   }

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -71,15 +71,7 @@ export default class HomeList extends Component {
       : "https://play.google.com/store/apps/details?id=com.discourse";
   }
 
-  get displayedTopics() {
-    const topics = this.homepageFilter.topicResults || [];
-    if (
-      !this.shouldShowPromo ||
-      (this.site.desktopView && !this.promoConfig.link)
-    ) {
-      return topics;
-    }
-
+  get promoCard() {
     const isDarkMode = window.matchMedia(
       "(prefers-color-scheme: dark)"
     ).matches;
@@ -103,8 +95,26 @@ export default class HomeList extends Component {
       topics_30_days: 0,
     };
 
+    return promoItem;
+  }
+
+  get displayedTopics() {
+    const topics = this.homepageFilter.topicResults || [];
+
+    if (
+      !this.shouldShowPromo ||
+      (this.site.desktopView && !this.promoConfig.link)
+    ) {
+      return topics;
+    }
+
     const insertAt = this.promoConfig.position - 1;
-    return [...topics.slice(0, insertAt), promoItem, ...topics.slice(insertAt)];
+
+    return [
+      ...topics.slice(0, insertAt),
+      this.promoCard,
+      ...topics.slice(insertAt),
+    ];
   }
 
   @action

--- a/javascripts/discourse/components/home-list.gjs
+++ b/javascripts/discourse/components/home-list.gjs
@@ -80,14 +80,22 @@ export default class HomeList extends Component {
       return topics;
     }
 
+    const isDarkMode = window.matchMedia(
+      "(prefers-color-scheme: dark)"
+    ).matches;
+
+    const promoImage = isDarkMode
+      ? this.promoConfig.dark_image_url
+      : this.promoConfig.image_url;
+
     const promoItem = {
       isPromo: true,
       featured_link: this.promoConfig.link || this.appStoreLink,
       title: this.promoConfig.title,
       excerpt: this.promoConfig.description,
       bannerImage: {
-        src: this.promoConfig.image_url,
-        srcset: `${this.promoConfig.image_url} 1x`,
+        src: promoImage,
+        srcset: `${promoImage} 1x`,
         sizes: "(max-width: 600px) 100vw, 50vw",
       },
       discover_entry_logo_url: "",

--- a/scss/promo.scss
+++ b/scss/promo.scss
@@ -1,0 +1,47 @@
+.discover-home .discover-list__item.--promo {
+  .discover-list__item-link {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    @media screen and (max-width: 768px) {
+      min-height: 25em;
+    }
+  }
+
+  h2 {
+    background: var(--secondary);
+    z-index: 2;
+    font-size: var(--font-up-2);
+    padding: 1.5rem 1.5rem 0.25rem;
+    margin: auto 0 0 0;
+  }
+
+  .discover-list__item-excerpt {
+    background: var(--secondary);
+    z-index: 2;
+    margin: 0;
+    padding: 0.25rem 1.5rem 1.5rem;
+  }
+
+  .no-image,
+  .discover-list__item-meta {
+    display: none;
+  }
+
+  .discover-list__item-banner {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+    border: 0;
+    z-index: 1;
+
+    img {
+      height: 100%;
+      width: 100%;
+      object-fit: cover;
+    }
+  }
+}

--- a/settings.yml
+++ b/settings.yml
@@ -31,7 +31,19 @@ locale_filter:
 
 promo_tile:
   type: objects
-  default: []
+  default:
+    [
+      {
+        "name": "promo",
+        "enabled": false,
+        "position": 5,
+        "title": "Try Discourse Hub!",
+        "description": "Find and follow your favorite communities in the official Discourse app.",
+        "link": "",
+        "image_url": "https://cdck-file-uploads-canada1.s3.dualstack.ca-central-1.amazonaws.com/discover/original/2X/d/df3bafbd73587c6ad59d0b7c6692713fb21b7c00.png",
+        "dark_image_url": "https://cdck-file-uploads-canada1.s3.dualstack.ca-central-1.amazonaws.com/discover/original/2X/0/006173523fd982e28784bd33a2ceb3bc55571c89.png",
+      },
+    ]
   schema:
     name: "promo"
     properties:
@@ -53,4 +65,4 @@ promo_tile:
         type: string
 
 svg_icons:
-  default: "user-astronaut"
+  default: ""

--- a/settings.yml
+++ b/settings.yml
@@ -39,16 +39,17 @@ promo_tile:
         type: boolean
       position:
         type: integer
-        default: 7
         validations:
           minimum: 1
       title:
         type: string
       description:
         type: string
+      link:
+        type: string
       image_url:
         type: string
-      link:
+      dark_image_url:
         type: string
 
 svg_icons:

--- a/settings.yml
+++ b/settings.yml
@@ -29,5 +29,27 @@ locale_filter:
       text:
         type: string
 
+promo_tile:
+  type: objects
+  default: []
+  schema:
+    name: "promo"
+    properties:
+      enabled:
+        type: boolean
+      position:
+        type: integer
+        default: 7
+        validations:
+          minimum: 1
+      title:
+        type: string
+      description:
+        type: string
+      image_url:
+        type: string
+      link:
+        type: string
+
 svg_icons:
   default: "user-astronaut"


### PR DESCRIPTION
This adds the ability to display a promo card: 

![image](https://github.com/user-attachments/assets/bbc13a7a-9bf5-494d-98f0-6856bd4cad4a)

When enabled, the promo is inserted into the topic results at the designated position. 

The promo can have an optional custom link added (eventually a link to our website). When the link field isn't populated, the card defaults to only appearing on mobile and linking directly to the relevant app store based on device type. 