### PR TITLE
FIX: Show a basic topic page for anon users

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -6,18 +6,6 @@
     "Noto Color Emoji";
 }
 
-html.anon {
-  body:not(.discover-home):not(.static-login):not(.has-sidebar-page) {
-    // hide other page content from anon users
-    display: none;
-  }
-  body[class=""] {
-    // the admin login route has no class
-    // so it's a special case
-    display: block !important;
-  }
-}
-
 @font-face {
   font-family: "Open Sans";
   src: url($open-sans) format("truetype");
@@ -545,6 +533,21 @@ html.anon {
   ul {
     margin-top: -0.5em;
     columns: 2;
+  }
+}
+
+// Topic view overrides for anons
+
+.anon {
+  .header-buttons .auth-buttons,
+  .d-header-icons,
+  .topic-category,
+  .topic-area .topic-map,
+  .topic-area .post-menu-area,
+  .topic-area .topic-meta-data,
+  .topic-area .topic-avatar,
+  #topic-footer-buttons {
+    display: none;
   }
 }
 

--- a/javascripts/discourse/initializers/init-force-home.gjs
+++ b/javascripts/discourse/initializers/init-force-home.gjs
@@ -12,6 +12,7 @@ export default apiInitializer("1.15.0", (api) => {
     const excludeRoutes = [
       "login",
       "email-login",
+      "topic.fromParams",
       `discovery.${defaultHomepage()}`,
     ];
 


### PR DESCRIPTION
For SEO, this is better than the redirect. Note that we don't link to this page from lists. 

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/a27912f6-aae8-4e3e-a7fc-3139c3974a50" />
